### PR TITLE
Fixed selectors for some class changes that Github made

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -72,3 +72,5 @@
 //  A number of refactorings and some automated tests were added (work in progress).
 // 1.0.3.20140818
 //  'Expand unreviewed' button was a child of 'Show diff stats' instead of being a sibling
+// 1.0.4.20150226
+//  Fixed selectors for some class changes that Github made

--- a/ghAssistant.meta.js
+++ b/ghAssistant.meta.js
@@ -2,7 +2,7 @@
 // @name            GitHub code review assistant
 // @description     Collapse & expand files one by one on diffs and mark them as reviewed. Useful to review commits with lots of files changed.
 // @icon            https://github.com/favicon.ico
-// @version         1.0.3.20140818
+// @version         1.0.4.20150226
 // @namespace       http://jakub-g.github.com/
 // @author          http://jakub-g.github.com/
 // @downloadURL     https://raw.githubusercontent.com/jakub-g/gh-code-review-assistant/master/ghAssistant.user.js

--- a/ghAssistant.user.js
+++ b/ghAssistant.user.js
@@ -167,7 +167,7 @@ gha.DomReader.getNumberOfFiles = function () {
 };
 
 gha.DomReader.getFilePathFromDiffContainerHeader = function (diffContainerHeader) {
-    return diffContainerHeader.querySelector('.info').children[1].innerHTML.trim();
+    return diffContainerHeader.querySelector('.file-info').children[1].innerHTML.trim();
 };
 
 // =================================================================================================
@@ -453,7 +453,7 @@ gha.DomWriter.attachPerDiffFileFeatures = function () {
 };
 
 gha.DomWriter.makeFileNameKeyboardAccessible = function (child) {
-    var fileNameSpan = child.querySelector('.info > .js-selectable-text');
+    var fileNameSpan = child.querySelector('.file-info > .js-selectable-text');
     // turns out getting parent is impossible after changing outerHTML, let's do it now
     var diffContainerBody = fileNameSpan.parentNode.parentNode.parentNode.children[1];
     fileNameSpan.className += ' ghaFileNameSpan';
@@ -486,7 +486,7 @@ gha.DomWriter._attachReviewStatusButton = function (diffContainer, text /*also c
     newButton.innerHTML = text;
     newButton.addEventListener('click', gha.ClickHandlers.createReviewButtonHandler(text, diffContainer));
 
-    var parentOfNewButton = diffContainer.querySelector('div.actions');
+    var parentOfNewButton = diffContainer.querySelector('div.file-actions');
     gha.DomUtil.insertAsFirstChild(newButton, parentOfNewButton);
 };
 
@@ -953,7 +953,7 @@ gha.VisibilityManager.toggleDisplayAll = function (iVisible, bKeepItemFromUrlHas
         var diffContainer = diffContainers[i];
         var diffContainerHeader = diffContainer.children[0];
         var diffContainerBody = diffContainer.children[1];
-        var fileName = diffContainer.querySelector('.meta').getAttribute('data-path');
+        var fileName = diffContainer.querySelector('.file-header').getAttribute('data-path');
 
         if (bKeepItemFromUrlHash && !iVisible && fileName == hashInUrl){
             continue;

--- a/ghAssistant.user.js
+++ b/ghAssistant.user.js
@@ -2,7 +2,7 @@
 // @name            GitHub code review assistant
 // @description     Collapse & expand files one by one on diffs and mark them as reviewed. Useful to review commits with lots of files changed.
 // @icon            https://github.com/favicon.ico
-// @version         1.0.3.20140818
+// @version         1.0.4.20150226
 // @namespace       http://jakub-g.github.com/
 // @author          http://jakub-g.github.com/
 // @downloadURL     https://raw.githubusercontent.com/jakub-g/gh-code-review-assistant/master/ghAssistant.user.js


### PR DESCRIPTION
Github decided to change some CSS classes so I've updated the selectors used in the script.
I've tested it using Tampermonkey on Chrome with pulls, commits and compares.
Also, updated the version so it will get auto updated.